### PR TITLE
added smooth blending on border edges

### DIFF
--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -55,18 +55,16 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
     // SDF distance in border area
     let dBorder = sdfRoundedBox(uv, input.size, input.border_radius);
 
-    // define the alpha value. Opaque if within the button or border area,
-    // transparent otherwise.
-    let alpha = select(1., 0., (dButton > 0. && dBorder > 0.));
-    // define the final color. Use `input.border_color` if within border
-    // radius, otherwise `input.background_color`.
+    // define the alpha value. Smoothly blend to avoid aliasing
+    let alpha = min(-min(dButton, dBorder), 1.0);
+    
+    // define the final color. Use `input.background_color` if not within border
+    // radius, otherwise smoothly blend from `input.background_color` to `input.border_color`.
     let color = select(
         input.background_color,
-        input.border_color,
+        mix(input.background_color, input.border_color, clamp(dButton, 0.0, 1.0)),
         (dButton > 0. && dBorder <= 0.),
     );
-
-    // TODO: Add color smoothing
 
     return vec4<f32>(color.rgb, alpha * color.a);
 }


### PR DESCRIPTION
I noticed a `TODO: Add color smoothing` in the shader code. As these aliasing artifacts started to bug me out I figured I'll just implement it myself. Pretty much the only thing I changed is that `dButton` is now used to smoothly transition from the background color to the border color. Same with the alpha value. I hope this is what you meant with this TODO.

| ![no_color_smoothing](https://github.com/robertdodd/bevy_round_ui/assets/44705673/1f1f494f-4660-452f-b1ba-b551dcea7ea4) | ![color_smooting](https://github.com/robertdodd/bevy_round_ui/assets/44705673/5d78e535-5bf4-4495-bf7e-aea91d6b5dba) |
|-|-|
| Without color smoothing | With color smoothing 🤩 |
